### PR TITLE
Generic saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ For target datasets with a mixture of code and natural language, consider splitt
 
 The `dsir` intermediate results (after `fit_importance_estimator` and `compute_importance_weights`) can be saved and loaded for later use, for example to resample 100M documents instead:
 ```python
-dsir.save('dsir_params_dir')
+dsir.save('dsir_params.pkl')
 
 # later on
-dsir.load('dsir_params_dir')
+dsir.load('dsir_params.pkl')
 dsir.resample(out_dir='resampled', num_to_sample=100000000, cache_dir='/scr/resampled_cache')
 ```
 The `save` method can be called at any time to save partial results.

--- a/data_selection/__init__.py
+++ b/data_selection/__init__.py
@@ -1,2 +1,9 @@
+try:
+    import importlib.metadata as importlib_metadata
+except ModuleNotFoundError:
+    import importlib_metadata
+
+__version__ = importlib_metadata.version('data-selection')
+
 from .base import DSIR
 from .hashed_ngram_dsir import HashedNgramDSIR

--- a/data_selection/base.py
+++ b/data_selection/base.py
@@ -45,6 +45,7 @@ def _iterate_virtually_sharded_dataset(dataset: Iterable, num_shards: int, shard
 
 class DSIR():
     """Base class for data selection with importance resampling (DSIR)."""
+    __version__ = '1.0.1'
 
     def __init__(self,
                  raw_datasets: List[str],
@@ -277,31 +278,17 @@ class DSIR():
 
     def save(self, path: str) -> None:
         """Save parameters to save computation"""
-        path = Path(path)
-        path.mkdir(parents=True, exist_ok=True)
-
-        metadata = {'raw_datasets': self.raw_datasets,
-                    'target_datasets': self.target_datasets,
-                    'raw_parse_example_fn': self.raw_parse_example_fn,
-                    'raw_load_dataset_fn': self.raw_load_dataset_fn,
-                    'target_parse_example_fn': self.target_parse_example_fn,
-                    'target_load_dataset_fn': self.target_load_dataset_fn,
-                    'log_importance_weights_dir': self.log_importance_weights_dir,
-                    'perexample_metadata_dir': self.perexample_metadata_dir,
-                    'cache_dir': self.cache_dir,
-                    }
-        # pickle the metadata
-        with open(str(path / 'metadata.pkl'), 'wb') as f:
-            pickle.dump(metadata, f)
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        with open(path, 'w') as f:
+            pickle.dump(self.__dict__, f)
 
     def load(self, path: str) -> None:
         """Load saved parameters"""
-        path = Path(path)
 
-        metadata_path = path / 'metadata.pkl'
-        with open(str(metadata_path), 'rb') as f:
-            metadata = pickle.load(f)
+        with open(path, 'r') as f:
+            params = pickle.load(f)
 
-        for k, v in metadata.items():
-            setattr(self, k, v)
+        if params.__version__ != self.__version__:
+            raise ValueError(f"Version mismatch: {params.__version__} != {self.__version__}")
+        self.__dict__.update(params)
 

--- a/data_selection/base.py
+++ b/data_selection/base.py
@@ -12,6 +12,7 @@ from datasets import load_dataset
 from tqdm import tqdm
 
 from data_selection.utils import parallelize
+from data_selection import __version__
 
 
 def default_load_dataset_fn(path: str) -> Iterable[Dict]:
@@ -45,7 +46,7 @@ def _iterate_virtually_sharded_dataset(dataset: Iterable, num_shards: int, shard
 
 class DSIR():
     """Base class for data selection with importance resampling (DSIR)."""
-    __version__ = '1.0.1'
+    __version__ = __version__
 
     def __init__(self,
                  raw_datasets: List[str],

--- a/data_selection/base.py
+++ b/data_selection/base.py
@@ -279,16 +279,24 @@ class DSIR():
     def save(self, path: str) -> None:
         """Save parameters to save computation"""
         Path(path).parent.mkdir(parents=True, exist_ok=True)
-        with open(path, 'w') as f:
-            pickle.dump(self.__dict__, f)
+        with open(path, 'wb') as f:
+            pickle.dump(self, f)
 
-    def load(self, path: str) -> None:
-        """Load saved parameters"""
+    def load(self, path: str, exclude_keys: Optional[List[str]] = None) -> None:
+        """Load saved parameters.
 
-        with open(path, 'r') as f:
-            params = pickle.load(f)
+        Args:
+        path: path to saved parameters
+        exclude_keys: keys to exclude from loading
+        """
 
-        if params.__version__ != self.__version__:
-            raise ValueError(f"Version mismatch: {params.__version__} != {self.__version__}")
-        self.__dict__.update(params)
+        with open(path, 'rb') as f:
+            obj = pickle.load(f)
 
+        if obj.__version__ != self.__version__:
+            raise ValueError(f"Version mismatch: {obj.__version__} != {self.__version__}")
+
+        for k, v in obj.__dict__.items():
+            if exclude_keys is not None and k in exclude_keys:
+                continue
+            setattr(self, k, v)

--- a/data_selection/hashed_ngram_dsir.py
+++ b/data_selection/hashed_ngram_dsir.py
@@ -56,6 +56,8 @@ def get_ngram_counts(line: str,
 
 
 class HashedNgramDSIR(DSIR):
+    """DSIR with hashed n-gram features."""
+    __version__ = '1.0.1'
 
     def __init__(self,
                  raw_datasets: List[str],
@@ -185,45 +187,3 @@ class HashedNgramDSIR(DSIR):
                 load_dataset_fn=self.target_load_dataset_fn)
 
         self.log_diff = np.log(self.target_probs + 1e-8) - np.log(self.raw_probs + 1e-8)
-
-    def save(self, path: str):
-        super().save(path)
-
-        path = Path(path)
-        if self.raw_probs is not None:
-            np.save(str(path / 'raw_probs.npy'), self.raw_probs)
-        if self.target_probs is not None:
-            np.save(str(path / 'target_probs.npy'), self.target_probs)
-        if self.log_diff is not None:
-            np.save(str(path / 'log_diff.npy'), self.log_diff)
-
-        with open(str(path / 'metadata.pkl'), 'rb') as f:
-            metadata = pickle.load(f)
-
-        metadata.update({
-            'num_buckets': self.num_buckets,
-            'ngrams': self.ngrams,
-            'tokenizer': self.tokenizer})
-
-        # pickle the metadata
-        with open(str(path / 'metadata.pkl'), 'wb') as f:
-            pickle.dump(metadata, f)
-
-
-    def load(self, path: str):
-        super().load(path)
-
-        path = Path(path)
-        raw_probs_path = path / 'raw_probs.npy'
-        if raw_probs_path.exists():
-            self.raw_probs = np.load(str(raw_probs_path))
-        target_probs_path = path / 'target_probs.npy'
-        if target_probs_path.exists():
-            self.target_probs = np.load(str(target_probs_path))
-
-        log_diff_path = path / 'log_diff.npy'
-        if log_diff_path.exists():
-            self.log_diff = np.load(str(log_diff_path))
-            assert(
-                np.allclose(self.log_diff, np.log(self.target_probs + 1e-8) - np.log(self.raw_probs + 1e-8)))
-

--- a/data_selection/hashed_ngram_dsir.py
+++ b/data_selection/hashed_ngram_dsir.py
@@ -57,7 +57,6 @@ def get_ngram_counts(line: str,
 
 class HashedNgramDSIR(DSIR):
     """DSIR with hashed n-gram features."""
-    __version__ = '1.0.1'
 
     def __init__(self,
                  raw_datasets: List[str],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "data-selection"
-version = "1.0.0"
+version = "1.0.1"
 authors = [
   { name="Sang Michael Xie", email="xie@cs.stanford.edu" },
 ]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 if __name__ == "__main__":
     setup(name='data-selection',
-          version='1.0.0',
+          version='1.0.1',
           description='Data Selection with Importance Resampling',
           url='https://github.com/p-lambda/dsir',
           author='Sang Michael Xie',

--- a/tests/test_hashed_ngram.py
+++ b/tests/test_hashed_ngram.py
@@ -194,10 +194,18 @@ def test_save_load(dsir_obj):
 
     dsir_obj.compute_importance_weights()
 
-    dsir_obj.save('/tmp/dsir')
+    dsir_obj.save('/tmp/dsir.pkl')
 
     dsir_obj_2 = HashedNgramDSIR([], [], 'cache')
-    dsir_obj_2.load('/tmp/dsir')
+    dsir_obj_2.load('/tmp/dsir.pkl', exclude_keys=['raw_datasets', 'target_datasets', 'cache_dir'])
+    assert np.allclose(dsir_obj_2.raw_probs, dsir_obj.raw_probs)
+    assert np.allclose(dsir_obj_2.target_probs, dsir_obj.target_probs)
+    assert np.allclose(dsir_obj_2.log_diff, dsir_obj.log_diff)
+    assert dsir_obj_2.num_buckets == dsir_obj.num_buckets
+    assert dsir_obj_2.ngrams == dsir_obj.ngrams
+
+    dsir_obj_2 = HashedNgramDSIR([], [], 'cache')
+    dsir_obj_2.load('/tmp/dsir.pkl')
 
     assert np.allclose(dsir_obj_2.raw_probs, dsir_obj.raw_probs)
     assert np.allclose(dsir_obj_2.target_probs, dsir_obj.target_probs)
@@ -207,16 +215,3 @@ def test_save_load(dsir_obj):
     assert dsir_obj_2.target_datasets == dsir_obj.target_datasets
     assert dsir_obj_2.num_buckets == dsir_obj.num_buckets
     assert dsir_obj_2.ngrams == dsir_obj.ngrams
-
-if __name__ == "__main__":
-    dsir = HashedNgramDSIR(
-            raw_datasets,
-            target_datasets,
-            cache_dir='/tmp/dsir_params',
-            raw_parse_example_fn=parse_example_fn,
-            target_parse_example_fn=parse_example_fn,
-            num_proc=2,
-            ngrams=2,
-            num_buckets=10000)
-
-    test_resample(dsir)


### PR DESCRIPTION
- makes save and load functions generic by just pickling the instance
- use version metadata from pyproject.toml and save it inside the object as metadata 
- exclude keys from being loaded in load